### PR TITLE
fix(features): add missing features

### DIFF
--- a/types/overwolf-dts/index.d.ts
+++ b/types/overwolf-dts/index.d.ts
@@ -179,6 +179,8 @@ export namespace ODK {
         |'summoner_info'
         |'gameMode'
         |'teams'
+        |'abilities'
+        |'level'
 
       interface AvailableFeaturesMapLOL extends ODK.GameEvents.AvailableFeaturesMap {
         matchState: TBuggedBoolean
@@ -194,6 +196,8 @@ export namespace ODK {
         summoner_info: TBuggedBoolean
         gameMode: TBuggedBoolean
         teams: TBuggedBoolean
+        abilities: TBuggedBoolean
+        level: TBuggedBoolean
       }
 
       type TCategoriesLOL = 'summoner_info'|'game_info'|'level'

--- a/types/overwolf-dts/index.d.ts
+++ b/types/overwolf-dts/index.d.ts
@@ -181,6 +181,7 @@ export namespace ODK {
         |'teams'
         |'abilities'
         |'level'
+        |'announcer'
 
       interface AvailableFeaturesMapLOL extends ODK.GameEvents.AvailableFeaturesMap {
         matchState: TBuggedBoolean
@@ -198,6 +199,7 @@ export namespace ODK {
         teams: TBuggedBoolean
         abilities: TBuggedBoolean
         level: TBuggedBoolean
+        announcer: TBuggedBoolean
       }
 
       type TCategoriesLOL = 'summoner_info'|'game_info'|'level'


### PR DESCRIPTION
`level` is required to get info updates for the summoner level.
`abilities` seems required because `spellsAndAbilities` doesn't work like expected. With `abilities` `ability` and `usedAbility` events are fired. `spellsAndAbilities` is not avaiable in the [docs ](http://developers.overwolf.com/documentation/sdk/overwolf/games/events/league-of-legends/) anymore.
`announcer` was added in [May 2017](http://developers.overwolf.com/changelog/version-105/). Not sure what it is used for.